### PR TITLE
Updates to make this work properly with the latest pinecone and openai

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 myenv/
+env/
+venv/
 .env
 *.py[cod]
 *$py.class

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,8 +4,11 @@ import os
 
 def create_app():
     app = Flask(__name__)
+    # Review this and correct for your environment
     if os.environ.get('FLASK_ENV') == 'development':
         CORS(app)
+    else:
+        CORS(app, resources={r"/*": {"origins": "*"}})
     from app.api.routes import api_blueprint
     app.register_blueprint(api_blueprint)
     return app

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -11,7 +11,10 @@ PINECONE_INDEX_NAME = 'index237'
 @api_blueprint.route('/handle-query', methods=['POST'])
 def handle_query():
     question = request.json['question']
-    chat_history = request.json['chatHistory']
+    try:
+        chat_history = request.json['chatHistory']
+    except KeyError:
+        chat_history = ""
     
     # Get the most similar chunks from Pinecone
     context_chunks = pinecone_service.get_most_similar_chunks_for_query(question, PINECONE_INDEX_NAME)

--- a/app/services/openai_service.py
+++ b/app/services/openai_service.py
@@ -49,4 +49,3 @@ def construct_llm_payload(question, context_chunks, chat_history):
   }
 
   return headers, data
-

--- a/app/services/pinecone_service.py
+++ b/app/services/pinecone_service.py
@@ -1,4 +1,4 @@
-from pinecome import Pinecone, ServerlessSpec
+from pinecone import Pinecone, ServerlessSpec
 from app.services.openai_service import get_embedding
 import os
 

--- a/app/services/pinecone_service.py
+++ b/app/services/pinecone_service.py
@@ -1,19 +1,23 @@
-import pinecone
+from pinecome import Pinecone, ServerlessSpec
 from app.services.openai_service import get_embedding
 import os
 
 PINECONE_API_KEY = os.environ.get('PINECONE_API_KEY')
-pinecone.init(api_key=PINECONE_API_KEY, environment='gcp-starter')
+pinecone = Pinecone(api_key=PINECONE_API_KEY, environment='MyLLMTest')
 EMBEDDING_DIMENSION = 1536
 
 def embed_chunks_and_upload_to_pinecone(chunks, index_name):
-    if index_name in pinecone.list_indexes():
+    if index_name in pinecone.list_indexes().names():
         print("\nIndex already exists. Deleting index ...")
         pinecone.delete_index(name=index_name)
     
     print("\nCreating a new index: ", index_name)
     pinecone.create_index(name=index_name,
-                          dimension=EMBEDDING_DIMENSION, metric='cosine')
+                          dimension=EMBEDDING_DIMENSION, metric='cosine',
+                          spec=ServerlessSpec(
+                            cloud="aws",
+                            region="us-west-2")
+    )
 
     index = pinecone.Index(index_name)
 
@@ -37,7 +41,7 @@ def get_most_similar_chunks_for_query(query, index_name):
 
     print("\nQuerying Pinecone index ...")
     index = pinecone.Index(index_name)
-    query_results = index.query(question_embedding, top_k=3, include_metadata=True)
+    query_results = index.query(vector=question_embedding, top_k=3, include_metadata=True)
     context_chunks = [x['metadata']['chunk_text'] for x in query_results['matches']]
 
     return context_chunks   

--- a/app/services/scraping_service.py
+++ b/app/services/scraping_service.py
@@ -2,7 +2,11 @@ import requests
 from bs4 import BeautifulSoup
 
 def scrape_website(url):
-    response = requests.get(url)
+    # Added a user agent to the header for scraping sites with mod_security turned on
+    headers ={
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0',
+    }
+    response = requests.get(url, headers=headers)
     soup = BeautifulSoup(response.content, 'html.parser')
     text = soup.get_text(separator='\n')
     return text


### PR DESCRIPTION
Made some updates, mostly to the pinecone service module. This wasn't working for me and I've corrected the following:

- pinecone.init() is no longer supported, it appears. I've updated to a new intantiation and import.
- Importing ServerlessSpec as it was not working for me without specifying this during Pinecone instantiation.
- pinecone.list_indexes().names() method is required and the index deletion wasn't working without it.
- Use of question_embedding when getting similar chunks wasn't working without specifying 'vector=' in the query arguments. Otherwise, it complains about the top_k placement for some weird reason.
- Added a user-agent in the header when scraping with BS4. Some sites deny access without it.
- Updated create_app() a little bit for CORS handling.
- A big one problem that can be very elusive: if you have an OpenAI account with pay-as-you-go. The GPT-4 preview won't work if you haven't added funds and checked the OpenAI sandbox prior to using this tutorial!